### PR TITLE
Passing specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 package-lock.json
+data/data.json

--- a/scripts/prepare_data.js
+++ b/scripts/prepare_data.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const neatCsv = require('neat-csv');
+const numericHeaders = [
+  'GWP',
+  'residenceTime',
+  'gwp_SAR_100',
+  'gwp_4AR_20',
+  'gwp_4AR_100',
+  'gwp_4AR_500',
+];
+const csvData = fs.readFileSync('data/data.csv', "utf8");
+neatCsv(csvData, {
+  mapValues: ({ header, index, value }) => {
+    if (numericHeaders.includes(header) ) {
+      return parseFloat(value) ? parseFloat(value) : null
+    } else return value
+  }
+}).then(function (data) {
+  fs.writeFileSync(__dirname + '/../data/data.json', JSON.stringify(data));
+})

--- a/src/gwp.js
+++ b/src/gwp.js
@@ -1,14 +1,13 @@
-const fs = require('fs').promises;
-const neatCsv = require('neat-csv');
-const readData = async (dataFile) => {
-  try {
-    const dataFile = await fs.open(dataFile, 'utf-8');
-    const data = await dataFile.readFile();
-    console.log(data);
-    await dataFile.close();
-    return data();
-  } catch (e) {
-    throw new Error(`Failed to load data file at ${dataFile}`);
+const gwpData = require('../data/data.json');
+
+const getData = function(gas) {
+  const match = gwpData.find(function (entry) {
+    return (entry.gas === gas)
+  });
+  if (match === undefined) {
+    throw new Error('Gas not found!')
   }
+  return match;
 }
-readData('../data/data.csv');
+
+module.exports.getData = getData;

--- a/src/gwp.js
+++ b/src/gwp.js
@@ -1,6 +1,6 @@
 const gwpData = require('../data/data.json');
 
-const getData = function(gas) {
+const getGas = function(gas) {
   const match = gwpData.find(function (entry) {
     return (entry.gas === gas)
   });
@@ -10,4 +10,4 @@ const getData = function(gas) {
   return match;
 }
 
-module.exports.getData = getData;
+module.exports.getGas = getGas;

--- a/test/gwp.test.js
+++ b/test/gwp.test.js
@@ -1,7 +1,7 @@
 const gwp = require('../src/gwp')
 
 test('gets Sulfur', () => {
-  expect(gwp.getData('SF6')).toEqual(
+  expect(gwp.getGas('SF6')).toEqual(
     {
       "GWP": 23900.000,
       "formula": "SF6",
@@ -16,4 +16,10 @@ test('gets Sulfur', () => {
       "units": ""
     }
   )
-});
+})
+
+test('GWP is a method', () => {
+  sulfur = gwp.getGas('SF6')
+  expect(sulfur.GWP).toEqual(23900);
+})
+;

--- a/test/gwp.test.js
+++ b/test/gwp.test.js
@@ -1,5 +1,19 @@
-const foo = require('../src/gwp')
+const gwp = require('../src/gwp')
 
-test('is FOOFOOF', () => {
-  expect(foo).toBe('FOOFOOF')
+test('gets Sulfur', () => {
+  expect(gwp.getData('SF6')).toEqual(
+    {
+      "GWP": 23900.000,
+      "formula": "SF6",
+      "gas": "SF6",
+      "gwp_4AR_100": 22800.000,
+      "gwp_4AR_20": 16300.000,
+      "gwp_4AR_500": 32600.000,
+      "gwp_SAR_100": 23900.000,
+      "name": "sulphur hexafluoride",
+      "residenceTime": 3200.000,
+      "source": "http://www.ipcc.ch/pdf/assessment-report/ar4/wg1/ar4-wg1-chapter2.pdf",
+      "units": ""
+    }
+  )
 });


### PR DESCRIPTION
Have a look at this.
     The way this module can be used right now is:
    
```js
    const gwp = require('../src/gwp')
    const gas = gwp.getData('SF6')
    console.log(gas.name)
```


